### PR TITLE
change title to playlist name on startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,7 +231,8 @@ function getPlaylist() {
     playlist = JSON.parse(playlist);
     videos = playlist;
     
-    if (videos[0] != undefined) {
+    if (videos[0] !== null && videos[0] !== undefined) {
+      document.title = "Streamly - " + decodeURIComponent(videos[0]);
       $("#playlistNameBox").val(decodeURIComponent(videos[0]));
     }
     


### PR DESCRIPTION
This is so that browsers cache the name of the playlist with the link