### PR TITLE
localizing the starting of autoplayWorking trying to remove bug of ra…

### DIFF
--- a/index.js
+++ b/index.js
@@ -411,12 +411,14 @@ function saveAutoplay() {
 
 function addAutoplayVideo() {
   if (playlistAutoplay && !autoplayWorking) {
-    autoplayWorking = true;
-    radioVideoIteration++;
     if (typeof autoplayMixUrl == 'undefined' || autoplayMixUrl === "") {
+      autoplayWorking = true;
+      radioVideoIteration++;
       getAutoplayUrl();
     }
     else if (videoIteration === videoCounter) {
+      autoplayWorking = true;
+      radioVideoIteration++;
       if (radioVideoIteration < radioVideos.length) {
         videoUrl = "https://www.youtube.com/watch?v=" + radioVideos[radioVideoIteration];
         getVideoData();


### PR DESCRIPTION
…dio stopping

I'm figuring that when addAutoplayVideo is being run, it is failing both the unset autoplayMixUrl and the latest video (iteration = counter), leaving autoplayWorking as true and locking out the entire addAutoplayVideo function. Cross your fingas.