### PR TITLE
empty the playlistNameBox because Firefox Quantum saves this value ov…

### DIFF
--- a/res/js/front/initialize.js
+++ b/res/js/front/initialize.js
@@ -18,7 +18,10 @@ window.onload = function() {
 
   $("footer").addClass("animated slideInUp").css("display", "initial");
   $("#links").addClass("animated fadeIn").css("display", "initial");
-
+  
+  //empty the playlistNameBox because Firefox Quantum saves this value over page re-loads
+  $("#playlistNameBox").val("");
+  
   $("#inputBox").focus();
 
   $("#inputBox").autocomplete({


### PR DESCRIPTION
…er page re-loads